### PR TITLE
README.md: Remove prolix ZHA config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ This custom quirk enables functionality for the Aqara W100 Climate Sensor in Hom
    - Edit your `configuration.yaml` file to include the custom quirks path:
      ```yaml
      zha:
-        database_path: /config/zigbee.db
-        enable_quirks: true
         custom_quirks_path: /config/custom_zha_quirks/ 
      ```
 


### PR DESCRIPTION
Just grabbed this to test with my w100. You don't need to throw the switch for `enable_quirks`. They are always enabled in late model ZHA: <https://github.com/zigpy/zha-device-handlers/pull/4349#discussion_r2360594929>

Only a reference to the quirks search path is needed.